### PR TITLE
Add sample for authoring packref compatible packages with interops

### DIFF
--- a/NuGet.Samples.Interop/IVsReferenceProperties.cs
+++ b/NuGet.Samples.Interop/IVsReferenceProperties.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace NuGet.Samples.Interop
+{
+    /// <summary>
+    /// Represents a collection of reference properties.
+    /// </summary>
+    [ComImport]
+    [Guid("29f7a567-9957-43fe-b45d-6ef69049742a")]
+    public interface IVsReferenceProperties : IEnumerable
+    {
+        /// <summary>
+        /// Total count of properties in container.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Retrieves a property by name or index.
+        /// </summary>
+        /// <param name="index">Property name or index.</param>
+        /// <returns>Property matching index.</returns>
+        IVsReferenceProperty Item(object index);
+    }
+}

--- a/NuGet.Samples.Interop/IVsReferenceProperty.cs
+++ b/NuGet.Samples.Interop/IVsReferenceProperty.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.Samples.Interop
+{
+    /// <summary>
+    /// Represents a property as a key-value pair
+    /// </summary>
+    [ComImport]
+    [Guid("1513778e-10b7-411e-a4d4-58dcbe51a9a5")]
+    public interface IVsReferenceProperty
+    {
+        /// <summary>
+        /// Property name.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Property value.
+        /// </summary>
+        string Value { get; }
+    }
+}

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.csproj
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.csproj
@@ -4,15 +4,13 @@
     <PackageId>NuGet.Samples.Interop</PackageId>
     <TargetFramework>net46</TargetFramework>
     <Shipping>true</Shipping>
-    <PackProject>true</PackProject>
-    <IncludeInVsix>true</IncludeInVsix>
     <authors>NuGet</authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/NuGet/NuGet.Client</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/NuGet/Samples/NuGet.Samples.Interop</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <AssemblyDescription>Sample Interop Package declaration</AssemblyDescription>
     <Description>Sample Interop Package declaration</Description>
-    <Copyright>Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>.NET Foundation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.csproj
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.csproj
@@ -6,7 +6,7 @@
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <IncludeInVsix>true</IncludeInVsix>
-    <authors>Microsoft</authors>
+    <authors>NuGet</authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/NuGet/NuGet.Client</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.csproj
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>NuGet.Samples.Interop</PackageId>
+    <TargetFramework>net46</TargetFramework>
+    <Shipping>true</Shipping>
+    <PackProject>true</PackProject>
+    <IncludeInVsix>true</IncludeInVsix>
+    <authors>Microsoft</authors>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/NuGet/NuGet.Client</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <AssemblyDescription>Sample Interop Package declaration</AssemblyDescription>
+    <Description>Sample Interop Package declaration</Description>
+    <Copyright>Microsoft Corporation. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="NuGet.Samples.Interop.targets">
+      <PackagePath>build</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.sln
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Samples.Interop", "NuGet.Samples.Interop.csproj", "{BA2057CD-1793-4A41-A2BB-2D2C9CE52445}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BA2057CD-1793-4A41-A2BB-2D2C9CE52445}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA2057CD-1793-4A41-A2BB-2D2C9CE52445}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA2057CD-1793-4A41-A2BB-2D2C9CE52445}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA2057CD-1793-4A41-A2BB-2D2C9CE52445}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8D76C559-CD3E-47EF-BBB0-80BAAB0CE59D}
+	EndGlobalSection
+EndGlobal

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- See https://github.com/NuGet/Home/issues/2365 for more info.
+       The decision whether an assembly needs to be linked or referenced belongs to the package author.
+       -->
+  <Target Name="LinkEmbeddableAssemblies" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
+    <ItemGroup>
+      <ReferencePath Condition=" '%(FileName)' == 'NuGet.Samples.Interop' ">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
@@ -5,7 +5,7 @@
        -->
   <Target Name="LinkEmbeddableAssemblies" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
     <ItemGroup>
-      <ReferencePath Condition=" '%(FileName)' == 'NuGet.Samples.Interop' ">
+      <ReferencePath Condition=" '%(FileName)' == 'NuGet.Samples.Interop' AND '%(ReferencePath.NuGetPackageId)' == 'NuGet.Samples.Interop' ">
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
@@ -14,7 +14,6 @@
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>
-    <Error Text="Remember, the target name should be a unique name for your specific package. We recommended making this target name as unique as possible. Delete this error line once you have done that" 
-    Condition="$'($_.Name)' == 'EmbeddingAssemblyNameFromPackageId'"/>
+    <Error Text="Remember, the target name should be a unique name for your specific package. We recommended making this target name as unique as possible. Delete this error line once you have done that" />
   </Target>
 </Project>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
@@ -2,12 +2,19 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- See https://github.com/NuGet/Home/issues/2365 for more info.
        The decision whether an assembly needs to be linked or referenced belongs to the package author.
+       It's very important that you make this target name as unique as possible to avoid clashes. Ideally you would include both you package name and the assembly being embedded in the name.
        -->
-  <Target Name="LinkEmbeddableAssemblies" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
+  <Target Name="EmbeddingAssemblyNameFromPackageId" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
+    <PropertyGroup>
+      <_InteropAssemblyFileName>NuGet.Samples.Interop</_InteropAssemblyFileName>
+    </PropertyGroup>
+    <!-- This target will set the EmbedInteropTypes metadata for the _InteropAssemblyFileName value in the current package. In order for a target to be executed in NuGet, the target name should be the same as the package id.-->
     <ItemGroup>
-      <ReferencePath Condition=" '%(FileName)' == 'NuGet.Samples.Interop' AND '%(ReferencePath.NuGetPackageId)' == '$(MSBuildThisFileName)' ">
+      <ReferencePath Condition=" '%(FileName)' == '$(_InteropAssemblyFileName)' AND '%(ReferencePath.NuGetPackageId)' == '$(MSBuildThisFileName)' ">
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>
+    <Error Text="Remember, the target name should be a unique name for your specific package. We recommended making this target name as unique as possible. Delete this error line once you have done that" 
+    Condition="$'($_.Name)' == 'EmbeddingAssemblyNameFromPackageId'"/>
   </Target>
 </Project>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
@@ -5,7 +5,7 @@
        -->
   <Target Name="LinkEmbeddableAssemblies" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
     <ItemGroup>
-      <ReferencePath Condition=" '%(FileName)' == 'NuGet.Samples.Interop' AND '%(ReferencePath.NuGetPackageId)' == 'NuGet.Samples.Interop' ">
+      <ReferencePath Condition=" '%(FileName)' == 'NuGet.Samples.Interop' AND '%(ReferencePath.NuGetPackageId)' == '$(MSBuildThisFileName)' ">
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>

--- a/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
+++ b/NuGet.Samples.Interop/NuGet.Samples.Interop.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- See https://github.com/NuGet/Home/issues/2365 for more info.
        The decision whether an assembly needs to be linked or referenced belongs to the package author.
-       It's very important that you make this target name as unique as possible to avoid clashes. Ideally you would include both you package name and the assembly being embedded in the name.
+       It's very important that you make this target name as unique as possible to avoid clashes. Ideally you would include both your package name and the assembly being embedded in the name.
        -->
   <Target Name="EmbeddingAssemblyNameFromPackageId" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
     <PropertyGroup>

--- a/NuGet.Samples.Interop/Properties/AssemblyInfo.cs
+++ b/NuGet.Samples.Interop/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// We're not really importing anything from a type library. This is just to make VS happy so we can embed interop types when 
+// referencing this assembly
+[assembly: ImportedFromTypeLib("NuGet.Samples.Interop")]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4003e1ab-70de-4b9c-8999-96161ee91d84")]

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -1,0 +1,11 @@
+This is a sample illustrating the recommended practice for authoring package reference compatible packages that contain interop assemblies. 
+
+In the past, NuGet packages used to be managed in two different ways – packages.config and project.json, each with their own set of advantages and limitations. With Visual Studio 2017 and .NET Core, we have improved the NuGet package management experience using PackageReference that brings new and improved capabilities such as deep MSBuild integration, improved performance for everyday tasks such as install and restore, multi-targeting and more. You can read the details in our blog post, https://blog.nuget.org/20170316/NuGet-now-fully-integrated-into-MSBuild.html.
+
+In the packages.config world, when adding the references to the project file, NuGet and Visual Studio would figure out which assemblies are interop or not and reference/link accordingly by adding the EmbedInteropTypes metadata if needed. 
+
+In the Package Reference world, due to performance considerations this is not done. We are recommending for package authors to explicitly specify which assemblies need to be embedded. 
+We recommed for this to be done via MsBuild targets in the package. 
+More information on that [here](https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#including-msbuild-props-and-targets-in-a-package). 
+
+The consumer of the package will still retain control over the package assemblies like in packages.config. The difference being that they need to add the metadata in their csproj specifically and that metadata will not being cleaned up by NuGet when a package is removed from the dependency list. 

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -2,18 +2,25 @@ This is a sample illustrating the recommended practice for authoring package ref
 
 In the past, NuGet packages used to be managed in two different ways – packages.config and project.json, each with their own set of advantages and limitations. With Visual Studio 2017 and .NET Core, we have improved the NuGet package management experience using PackageReference that brings new and improved capabilities such as deep MSBuild integration, improved performance for everyday tasks such as install and restore, multi-targeting and more. You can read the details in our blog post, https://blog.nuget.org/20170316/NuGet-now-fully-integrated-into-MSBuild.html.
 
-In the packages.config case, no special authoring was needed for packages contain interop assemblies because when adding references to the project file NuGet and Visual Studio would test which assemblies are interop and set the EmbedInteropTypes to true.
-In Package Reference case,  due to performance considerations this is not done. The EmbedInteropTypes metadata is always false for all assemblies.
+Packages that contain COM interop assemblies need to include an appropriate targets file so that the correct `EmbedInteropTypes` metadata is added to projects using the PackageReference format.
 
-We are recommending for package authors to explicitly specify which assemblies need to be embedded. 
-We recommend for this to be done via MsBuild targets in the package. 
-More information on that [here](https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package). 
+By default, the `EmbedInteropTypes` metadata is always false for all assemblies when PackageReference is used. Package authors must explicitly add this metadata by including a [targets file](#including-msbuild-props-and-targets-in-a-package). The target name should be unique to avoid conflicts; ideally, use a combination of your package name and the assembly being embedded. For an example, see [NuGet.Samples.Interop](https://github.com/NuGet/Samples/tree/master/NuGet.Samples.Interop).
 
-**Note**
-By default the build assets will not flow transitively. 
-The [default value for private assets](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets) is:
+```xml      
+<Target Name="EmbeddingAssemblyNameFromPackageId" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
+  <PropertyGroup>
+    <_InteropAssemblyFileName>{InteropAssemblyName}</_InteropAssemblyFileName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ReferencePath Condition=" '%(FileName)' == '$(_InteropAssemblyFileName)' AND '%(ReferencePath.NuGetPackageId)' == '$(MSBuildThisFileName)' ">
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </ReferencePath>
+  </ItemGroup>
+</Target>
 ```
-<PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
-```
 
+Note that when using the `packages.config` reference format, adding references to the assemblies from the packages causes NuGet and Visual Studio to check for COM interop assemblies and set the `EmbedInteropTypes` to true in the project file. In this case the targets are overriden.
+
+Additionally, by default the [build assets do not flow transitively](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets). 
 Packages authored this way, will work differently when they are a pulled as a transitive dependency from a project to project reference. 
+The package consumer can allow them to flow by modifying the PrivateAssets default value. 

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -21,6 +21,4 @@ By default, the `EmbedInteropTypes` metadata is always false for all assemblies 
 
 Note that when using the `packages.config` reference format, adding references to the assemblies from the packages causes NuGet and Visual Studio to check for COM interop assemblies and set the `EmbedInteropTypes` to true in the project file. In this case the targets are overriden.
 
-Additionally, by default the [build assets do not flow transitively](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets). 
-Packages authored this way, will work differently when they are a pulled as a transitive dependency from a project to project reference. 
-The package consumer can allow them to flow by modifying the PrivateAssets default value. 
+Additionally, by default the [build assets do not flow transitively](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets).  Packages authored as described here work differently when they are pulled as a transitive dependency from a project to project reference. The package consumer can allow them to flow by modifying the PrivateAssets default value to not include build.

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -16,4 +16,5 @@ The default value for private assets is:
 <PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
 ```
 [More info](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets)
+
 Packages authored this way, will work differently when they are a pulled as a transitive dependency from a project to project reference. 

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -11,10 +11,9 @@ More information on that [here](https://docs.microsoft.com/en-us/nuget/create-pa
 
 **Note**
 By default the build assets will not flow transitively. 
-The default value for private assets is:
+The [default value for private assets](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets) is:
 ```
 <PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
 ```
-[More info](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets)
 
 Packages authored this way, will work differently when they are a pulled as a transitive dependency from a project to project reference. 

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -6,5 +6,14 @@ In the packages.config case, no special authoring was needed for packages contai
 In Package Reference case,  due to performance considerations this is not done. The EmbedInteropTypes metadata is always false for all assemblies.
 
 We are recommending for package authors to explicitly specify which assemblies need to be embedded. 
-We recommed for this to be done via MsBuild targets in the package. 
+We recommend for this to be done via MsBuild targets in the package. 
 More information on that [here](https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package). 
+
+**Note**
+By default the build assets will not flow transitively. 
+The default value for private assets is:
+```
+<PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
+```
+[More info](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets)
+Packages authored this way, will work differently when they are a pulled as a transitive dependency from a project to project reference. 

--- a/NuGet.Samples.Interop/README.md
+++ b/NuGet.Samples.Interop/README.md
@@ -2,10 +2,9 @@ This is a sample illustrating the recommended practice for authoring package ref
 
 In the past, NuGet packages used to be managed in two different ways – packages.config and project.json, each with their own set of advantages and limitations. With Visual Studio 2017 and .NET Core, we have improved the NuGet package management experience using PackageReference that brings new and improved capabilities such as deep MSBuild integration, improved performance for everyday tasks such as install and restore, multi-targeting and more. You can read the details in our blog post, https://blog.nuget.org/20170316/NuGet-now-fully-integrated-into-MSBuild.html.
 
-In the packages.config world, when adding the references to the project file, NuGet and Visual Studio would figure out which assemblies are interop or not and reference/link accordingly by adding the EmbedInteropTypes metadata if needed. 
+In the packages.config case, no special authoring was needed for packages contain interop assemblies because when adding references to the project file NuGet and Visual Studio would test which assemblies are interop and set the EmbedInteropTypes to true.
+In Package Reference case,  due to performance considerations this is not done. The EmbedInteropTypes metadata is always false for all assemblies.
 
-In the Package Reference world, due to performance considerations this is not done. We are recommending for package authors to explicitly specify which assemblies need to be embedded. 
+We are recommending for package authors to explicitly specify which assemblies need to be embedded. 
 We recommed for this to be done via MsBuild targets in the package. 
-More information on that [here](https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#including-msbuild-props-and-targets-in-a-package). 
-
-The consumer of the package will still retain control over the package assemblies like in packages.config. The difference being that they need to add the metadata in their csproj specifically and that metadata will not being cleaned up by NuGet when a package is removed from the dependency list. 
+More information on that [here](https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package). 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2365. 

Adding a package reference compatible package authoring for packages with interops. 

Fixes the above mentioned issue. 
Due to performance considerations we have decided to go the route where the package author is the one controlling the linking/referencing of assemblies. 

I have attached a readme here detailing our decision  and some background about. 
Docs PR
NuGet/docs.microsoft.com-nuget#506
// cc @anangaur, @rrelyea 