### PR TITLE
Removed Target tag causing invalid XML #16

### DIFF
--- a/ExtensionSDKasNuGetPackage/NativePackage/Targets/uap/10.0.14393/MyNativePackage.targets
+++ b/ExtensionSDKasNuGetPackage/NativePackage/Targets/uap/10.0.14393/MyNativePackage.targets
@@ -7,7 +7,6 @@
        		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
    	</Content>
     </ItemGroup>
-  <Target Name="BeforeBuild">
 <Target Name="TPMinVCheck" BeforeTargets="Build;ReBuild" Condition="'$(TargetPlatformMinVersion)' != ''">
      <PropertyGroup>
     <RequiredTPMinV>10.0.14393</RequiredTPMinV>

--- a/ExtensionSDKasNuGetPackage/NativePackage/Targets/uap/10.0/MyNativePackage.targets
+++ b/ExtensionSDKasNuGetPackage/NativePackage/Targets/uap/10.0/MyNativePackage.targets
@@ -7,7 +7,6 @@
        		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
    	</Content>
     </ItemGroup>
-  <Target Name="BeforeBuild">
 <Target Name="TPMinVCheck" BeforeTargets="Build;ReBuild" Condition="'$(TargetPlatformMinVersion)' != ''">
      <PropertyGroup>
     <RequiredTPMinV>10.0.14393</RequiredTPMinV>


### PR DESCRIPTION
This fixes an issue when importing and building a generated MyNativePackage .nupkg into a new UWP app.