### PR TITLE
Minor fix to BaseCatalogLeafConverter in CatalogReaderExample.

### DIFF
--- a/CatalogReaderExample/NuGet.Protocol.Catalog/Serialization/BaseCatalogLeafConverter.cs
+++ b/CatalogReaderExample/NuGet.Protocol.Catalog/Serialization/BaseCatalogLeafConverter.cs
@@ -27,6 +27,7 @@ namespace NuGet.Protocol.Catalog
             if (_fromType.TryGetValue((CatalogLeafType)value, out output))
             {
                 writer.WriteValue(output);
+                return;
             }
 
             throw new NotSupportedException($"The catalog leaf type '{value}' is not supported.");


### PR DESCRIPTION
This is a minor fix to the BaseCatalogLeafConverter in the CatalogReaderExample example project.
When trying to serialize a CatalogLeafItem back to JSON, it throwed a NotSupported exception.
Expected behaviour is that it would correctly serialize the CatalogLeafItem.